### PR TITLE
Domain and geo globus export

### DIFF
--- a/harvester/DBInterface.py
+++ b/harvester/DBInterface.py
@@ -942,10 +942,12 @@ class DBInterface:
 
                     if geoplace_id is None:
                         geoplace_id = self.insert_related_record("geoplace", geoplace["place_name"], **extras)
+                        modified_upstream = True
                     if geoplace_id is not None:
                         new_geoplace_ids.append(geoplace_id)
                         if geoplace_id not in existing_geoplace_ids:
                             self.insert_cross_record("records_x_geoplace", "geoplace", geoplace_id, record["record_id"])
+                            modified_upstream = True
 
                 for eid in existing_geoplace_ids:
                     if eid not in new_geoplace_ids:

--- a/harvester/Exporter.py
+++ b/harvester/Exporter.py
@@ -105,7 +105,7 @@ class Exporter(object):
                     con.row_factory = Row
                     litecur = con.cursor()
                 elif self.db.getType() == "postgres":
-                    litecur = con.cursor(cursor_factory=None)
+                    litecur = con.cursor(cursor_factory=DictCursor)
 
                 litecur.execute(self.db._prep("""SELECT geobbox.westLon, geobbox.eastLon, geobbox.northLat, geobbox.southLat
                                     FROM geobbox WHERE geobbox.record_id=?"""), (record["record_id"],))
@@ -209,7 +209,7 @@ class Exporter(object):
                     con.row_factory = Row
                     litecur = con.cursor()
                 elif self.db.getType() == "postgres":
-                    litecur = con.cursor(cursor_factory=None)
+                    litecur = con.cursor(cursor_factory=DictCursor)
 
                 litecur.execute(self.db._prep(
                     "SELECT ds.namespace, dm.field_name, dm.field_value FROM domain_metadata dm, domain_schemas ds WHERE dm.schema_id=ds.schema_id and dm.record_id=?"),

--- a/harvester/Exporter.py
+++ b/harvester/Exporter.py
@@ -113,10 +113,10 @@ class Exporter(object):
                 if len(geobboxes) > 0:
                     record["datacite_geoLocationBox"] = []
                     for geobbox in geobboxes:
-                        record["datacite_geoLocationBox"].append({"westBoundLongitude": geobbox["westLon"],
-                                                                  "eastBoundLongitude": geobbox["eastLon"],
-                                                                  "northBoundLatitude": geobbox["northLat"],
-                                                                  "southBoundLatitude": geobbox["southLat"]})
+                        record["datacite_geoLocationBox"].append({"westBoundLongitude": float(geobbox["westlon"]),
+                                                                  "eastBoundLongitude": float(geobbox["eastlon"]),
+                                                                  "northBoundLatitude": float(geobbox["northlat"]),
+                                                                  "southBoundLatitude": float(geobbox["southlat"])})
 
 
                 litecur.execute(self.db._prep("""SELECT geopoint.lat, geopoint.lon FROM geopoint WHERE geopoint.record_id=?"""), (record["record_id"],))
@@ -124,8 +124,8 @@ class Exporter(object):
                 if len(geopoints) > 0:
                     record["datacite_geoLocationPoint"] = []
                     for geopoint in geopoints:
-                        record["datacite_geoLocationPoint"].append({"pointLatitude": geopoint["lat"],
-                                                                    "pointLongitude": geopoint["lon"]})
+                        record["datacite_geoLocationPoint"].append({"pointLatitude": float(geopoint["lat"]),
+                                                                    "pointLongitude": float(geopoint["lon"])})
 
                 litecur.execute(self.db._prep("""SELECT geoplace.country, geoplace.province_state, geoplace.city, geoplace.other, geoplace.place_name
                     FROM geoplace JOIN records_x_geoplace on records_x_geoplace.geoplace_id = geoplace.geoplace_id

--- a/harvester/Exporter.py
+++ b/harvester/Exporter.py
@@ -218,7 +218,10 @@ class Exporter(object):
                     domain_namespace = str(row["namespace"])
                     field_name = str(row["field_name"])
                     field_value = str(row["field_value"])
-                    custom_label = domain_namespace + "#" + field_name
+                    if domain_namespace == "http://datacite.org/schema/kernel-4":
+                        custom_label = "datacite_" + field_name
+                    else:
+                        custom_label = domain_namespace + "#" + field_name
                     if custom_label not in record:
                         record[custom_label] = field_value
                     else:

--- a/harvester/OAIRepository.py
+++ b/harvester/OAIRepository.py
@@ -356,6 +356,9 @@ class OAIRepository(HarvestRepository):
         excludedElements = ['http://datacite.org/schema/kernel-4#resourcetype',
                     'http://datacite.org/schema/kernel-4#creatorAffiliation',
                     'http://datacite.org/schema/kernel-4#publicationyear',
+                    'http://datacite.org/schema/kernel-4#geolocationPlace',
+                    'http://datacite.org/schema/kernel-4#geolocationPoint',
+                    'http://datacite.org/schema/kernel-4#geolocationBox',
                     'https://www.frdr-dfdr.ca/schema/1.0/#globusEndpointName',
                     'https://www.frdr-dfdr.ca/schema/1.0/#globusEndpointPath']
         newRecord = {}


### PR DESCRIPTION
This code implements changes to the exporter for geospatial and domain metadata.

**Geospatial metadata** is now in this structure:

"datacite_geoLocationBox": [
            {
              "westBoundLongitude": -108.033431,
              "eastBoundLongitude": -106.412536,
              "northBoundLatitude": 51.296637,
              "southBoundLatitude": 50.623158
            }
          ],
"datacite_geoLocationPoint": [
            {
              "pointLatitude": 48,
              "pointLongitude": -63
            },
            {
              "pointLatitude": 42.5,
              "pointLongitude": -69
            }
          ],

_For a single place-name:_
"datacite_geoLocationPlace": [
            {
              "place_name": "South West Nova Scotia"
            }
_For Dataverse-style subfields:_
"datacite_geoLocationPlace": [
            {
              "country": "Canada",
              "province_state": "",
              "city": "",
              "additional": ""
            },
            {
              "country": "",
              "province_state": "",
              "city": "",
              "additional": "Turkey Point, Ontario"
            }
          ],

**Domain metadata** now uses "namespace#fieldname" format, instead of the "frdrcust1" we had previously (e.g FRDRCUST1#DATECOLLECTED). However, if the namespace is the URL for DataCite's schema, we change this to "datacite_" for consistency (e.g. "datacite_dateCollected").

I also updated DBInterface to properly delete "stale" domain metadata.