### PR TITLE
FRDR repository expanded metadata

### DIFF
--- a/harvester/DBInterface.py
+++ b/harvester/DBInterface.py
@@ -471,10 +471,11 @@ class DBInterface:
                     return record["dc:source"]
 
         # URL is in the identifier
-        local_url = re.search("(http|ftp|https)://([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?",
-                              record["local_identifier"])
-        if local_url:
-            return local_url.group(0)
+        if "local_identifier" in record:
+            local_url = re.search("(http|ftp|https)://([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?",
+                                  record["local_identifier"])
+            if local_url:
+                return local_url.group(0)
 
         self.logger.error("construct_local_url() failed for item: {}".format(json.dumps(record)) )
         return None

--- a/harvester/OAIRepository.py
+++ b/harvester/OAIRepository.py
@@ -229,6 +229,19 @@ class OAIRepository(HarvestRepository):
             if "http://datacite.org/schema/kernel-4#creatorAffiliation" in record:
                 record["affiliation"] = record.get("http://datacite.org/schema/kernel-4#creatorAffiliation")
 
+            # Add contributors
+            record["contributor"] = []
+            for contributorType in ['DataCollector', 'DataManager', 'ProjectManager', 'ResearchGroup', 'Sponsor', 'Supervisor', 'Other']:
+                dataciteContributorType = 'http://datacite.org/schema/kernel-4#contributor' + contributorType
+                if dataciteContributorType in record:
+                    for contributor in record[dataciteContributorType]:
+                        if contributor not in record["contributor"]:
+                            record["contributor"].append(contributor)
+
+            if len(record["contributor"]) == 0:
+                record.pop("contributor")
+
+
         if 'identifier' not in record.keys():
             return None
         if record["pub_date"] is None:
@@ -364,7 +377,14 @@ class OAIRepository(HarvestRepository):
                     'http://datacite.org/schema/kernel-4#geolocationPoint',
                     'http://datacite.org/schema/kernel-4#geolocationBox',
                     'https://www.frdr-dfdr.ca/schema/1.0/#globusEndpointName',
-                    'https://www.frdr-dfdr.ca/schema/1.0/#globusEndpointPath']
+                    'https://www.frdr-dfdr.ca/schema/1.0/#globusEndpointPath',
+                    'http://datacite.org/schema/kernel-4#contributorDataCollector',
+                    'http://datacite.org/schema/kernel-4#contributorDataManager',
+                    'http://datacite.org/schema/kernel-4#contributorProjectManager',
+                    'http://datacite.org/schema/kernel-4#contributorResearchGroup',
+                    'http://datacite.org/schema/kernel-4#contributorSponsor',
+                    'http://datacite.org/schema/kernel-4#contributorSupervisor',
+                    'http://datacite.org/schema/kernel-4#contributorOther']
         newRecord = {}
         for elementName in list(record.keys()):
             if '#' in elementName:

--- a/harvester/OAIRepository.py
+++ b/harvester/OAIRepository.py
@@ -339,7 +339,7 @@ class OAIRepository(HarvestRepository):
         if "series" not in record.keys():
             record["series"] = ""
 
-        if "coverage" in record.keys():
+[None]        if "coverage" in record.keys() and not record["coverage"] == [None]:
             record["geoplaces"] = []
             if self.name == "SFU Radar":
                 record["coverage"] = [x.strip() for x in record["coverage"][0].split(";")]

--- a/harvester/OAIRepository.py
+++ b/harvester/OAIRepository.py
@@ -159,6 +159,9 @@ class OAIRepository(HarvestRepository):
             except StopIteration:
                 break
 
+            except Exception as e:
+                self.logger.debug("Exception while working on item {}: {}".format(item_count, e))
+
         self.logger.info("Processed {} items in feed".format(item_count))
 
     def unpack_oai_metadata(self, record):

--- a/harvester/OAIRepository.py
+++ b/harvester/OAIRepository.py
@@ -384,7 +384,11 @@ class OAIRepository(HarvestRepository):
                     'http://datacite.org/schema/kernel-4#contributorResearchGroup',
                     'http://datacite.org/schema/kernel-4#contributorSponsor',
                     'http://datacite.org/schema/kernel-4#contributorSupervisor',
-                    'http://datacite.org/schema/kernel-4#contributorOther']
+                    'http://datacite.org/schema/kernel-4#contributorOther',
+                    'http://datacite.org/schema/kernel-4#creatorNameIdentifier',
+                    'http://datacite.org/schema/kernel-4#fundingReferenceFunderName',
+                    'http://datacite.org/schema/kernel-4#fundingReferenceAwardNumber',
+                    'http://datacite.org/schema/kernel-4#fundingReferenceAwardTitle']
         newRecord = {}
         for elementName in list(record.keys()):
             if '#' in elementName:


### PR DESCRIPTION
Display FRDR's datacite_contributor fields as part of "contributor". Related Identifiers are now part of domain metadata, but nameIdentifier and funder fields are excluded for now. 

Bug fixes:
- an exception other than AttributeError or StopIteration stopped all harvesting for an OAI repository; now it just fails for that specific record
- in construct_local_url, don't reference local_url when it may not have been assigned yet