### PR TITLE
Use the full OAI XML response to get nested creator and CRDC metadata

### DIFF
--- a/harvester/OAIRepository.py
+++ b/harvester/OAIRepository.py
@@ -269,14 +269,16 @@ class OAIRepository(HarvestRepository):
             # Add creators and affiliations from full XML
             record["creator"] = []
             record["affiliation"] = []
-            for creator_xml in list(frdr_xml.find("{http://datacite.org/schema/kernel-4}creators")):
-                record["creator"].append(creator_xml.find("{http://datacite.org/schema/kernel-4}creatorName").text)
-                for affiliation_xml in creator_xml.findall("{http://datacite.org/schema/kernel-4}affiliation"):
-                    if affiliation_xml.get("affiliationIdentifier"):
-                        record["affiliation"].append({"affiliation_name": affiliation_xml.text,
-                                                      "affiliation_ror": affiliation_xml.get("affiliationIdentifier")})
-                    else:
-                        record["affiliation"].append(affiliation_xml.text)
+
+            if frdr_xml.find("{http://datacite.org/schema/kernel-4}creators"):
+                for creator_xml in list(frdr_xml.find("{http://datacite.org/schema/kernel-4}creators")):
+                    record["creator"].append(creator_xml.find("{http://datacite.org/schema/kernel-4}creatorName").text)
+                    for affiliation_xml in creator_xml.findall("{http://datacite.org/schema/kernel-4}affiliation"):
+                        if affiliation_xml.get("affiliationIdentifier"):
+                            record["affiliation"].append({"affiliation_name": affiliation_xml.text,
+                                                          "affiliation_ror": affiliation_xml.get("affiliationIdentifier")})
+                        else:
+                            record["affiliation"].append(affiliation_xml.text)
 
             if "dateissued" in record:
                 record["pub_date"] = record["dateissued"]

--- a/harvester/OAIRepository.py
+++ b/harvester/OAIRepository.py
@@ -175,7 +175,7 @@ class OAIRepository(HarvestRepository):
 
                 # Use the header id for the database key (needed later for OAI GetRecord calls)
                 metadata["identifier"] = record.header.identifier
-                oai_record = self.unpack_oai_metadata(metadata)
+                oai_record = self.unpack_oai_metadata(metadata, record.xml)
                 self.domain_metadata = self.find_domain_metadata(metadata)
                 self.db.write_record(oai_record, self)
                 item_count = item_count + 1
@@ -197,7 +197,7 @@ class OAIRepository(HarvestRepository):
 
         self.logger.info("Processed {} items in feed".format(item_count))
 
-    def unpack_oai_metadata(self, record):
+    def unpack_oai_metadata(self, record, record_xml):
         record["pub_date"] = record.get("date")
 
         if self.metadataprefix.lower() == "ddi":
@@ -240,22 +240,43 @@ class OAIRepository(HarvestRepository):
 
         # Parse FRDR records
         if self.metadataprefix.lower() == "frdr":
-            if "https://www.frdr-dfdr.ca/schema/1.0/#crdc" in record:
-                record["crdc"] = []
-                crdc_index = 0
-                while crdc_index < len(record["https://www.frdr-dfdr.ca/schema/1.0/#crdcCode"]):
-                    en_index = crdc_index*2
-                    fr_index = en_index + 1
-                    record["crdc"].append({
-                        "crdc_code": record["https://www.frdr-dfdr.ca/schema/1.0/#crdcCode"][crdc_index],
-                        "crdc_group_en": record["https://www.frdr-dfdr.ca/schema/1.0/#crdcGroup"][en_index],
-                        "crdc_group_fr": record["https://www.frdr-dfdr.ca/schema/1.0/#crdcGroup"][fr_index],
-                        "crdc_class_en": record["https://www.frdr-dfdr.ca/schema/1.0/#crdcClass"][en_index],
-                        "crdc_class_fr": record["https://www.frdr-dfdr.ca/schema/1.0/#crdcClass"][fr_index],
-                        "crdc_field_en": record["https://www.frdr-dfdr.ca/schema/1.0/#crdcField"][en_index],
-                        "crdc_field_fr": record["https://www.frdr-dfdr.ca/schema/1.0/#crdcField"][fr_index],
-                    })
-                    crdc_index += 1
+            frdr_xml = record_xml.find("{http://www.openarchives.org/OAI/2.0/}metadata").find("{https://www.frdr-dfdr.ca/schema/1.0/}frdr")
+
+            # Add CRDC from full XML
+            record["crdc"] = []
+            for crdc_xml in frdr_xml.findall("{https://www.frdr-dfdr.ca/schema/1.0/}crdc"):
+                crdc_entry = {}
+                crdc_entry["crdc_code"] = crdc_xml.find("{https://www.frdr-dfdr.ca/schema/1.0/}crdcCode").text
+                for crdc_group in crdc_xml.findall("{https://www.frdr-dfdr.ca/schema/1.0/}crdcGroup"):
+                    if crdc_group.get("{http://www.w3.org/XML/1998/namespace}lang") == "en":
+                        crdc_entry["crdc_group_en"] = crdc_group.text
+                    elif crdc_group.get("{http://www.w3.org/XML/1998/namespace}lang") == "fr":
+                        crdc_entry["crdc_group_fr"] = crdc_group.text
+                for crdc_class in crdc_xml.findall("{https://www.frdr-dfdr.ca/schema/1.0/}crdcClass"):
+                    if crdc_class.get("{http://www.w3.org/XML/1998/namespace}lang") == "en":
+                        crdc_entry["crdc_class_en"] = crdc_class.text
+                    elif crdc_class.get("{http://www.w3.org/XML/1998/namespace}lang") == "fr":
+                        crdc_entry["crdc_class_fr"] = crdc_class.text
+                for crdc_field in crdc_xml.findall("{https://www.frdr-dfdr.ca/schema/1.0/}crdcField"):
+                    if crdc_field.get("{http://www.w3.org/XML/1998/namespace}lang") == "en":
+                        crdc_entry["crdc_field_en"] = crdc_field.text
+                    elif crdc_field.get("{http://www.w3.org/XML/1998/namespace}lang") == "fr":
+                        crdc_entry["crdc_field_fr"] = crdc_field.text
+                record["crdc"].append(crdc_entry)
+            if len(record["crdc"]) == 0:
+                record.pop("crdc")
+
+            # Add creators and affiliations from full XML
+            record["creator"] = []
+            record["affiliation"] = []
+            for creator_xml in list(frdr_xml.find("{http://datacite.org/schema/kernel-4}creators")):
+                record["creator"].append(creator_xml.find("{http://datacite.org/schema/kernel-4}creatorName").text)
+                for affiliation_xml in creator_xml.findall("{http://datacite.org/schema/kernel-4}affiliation"):
+                    if affiliation_xml.get("affiliationIdentifier"):
+                        record["affiliation"].append({"affiliation_name": affiliation_xml.text,
+                                                      "affiliation_ror": affiliation_xml.get("affiliationIdentifier")})
+                    else:
+                        record["affiliation"].append(affiliation_xml.text)
 
             if "dateissued" in record:
                 record["pub_date"] = record["dateissued"]
@@ -549,7 +570,7 @@ class OAIRepository(HarvestRepository):
             metadata["identifier"] = single_record.header.identifier
             metadata["geodisy_harvested"] = single_record.get("geodisy_harvested", 0) # FIXME exception thrown here, FRDRRecord does not have "get"
             metadata["fizes_size"] = single_record.get("files_size", 0) # FIXME this would also thrown an exception if it were reachable
-            oai_record = self.unpack_oai_metadata(metadata)
+            oai_record = self.unpack_oai_metadata(metadata, record.xml)
             self.domain_metadata = self.find_domain_metadata(metadata)
             if oai_record is None:
                 self.db.delete_record(record)


### PR DESCRIPTION
We had been using a workaround to get the nested CRDC information (group/class/field/code) out of Sickle's "metadata" response, which flattens XML. With the addition of ROR IDs to affiliation metadata, I updated OAIRepository to parse the full XML (etree) to get nested metadata and XML element attributes.

Tested using dev6, repos.json:

```
{
    "repos": [
        {
            "name": "FRDR",
            "type": "oai",
            "url": "https://dev6.frdr.ca/oai/request",
            "homepage_url": "https://{{ web_hostname }}/",
            "thumbnail": "https://{{ web_hostname }}/discover/img/sources/frdr_80x80.png",
            "set": "col_123456789_2",
            "metadataprefix": "frdr",
            "repo_refresh_days": 0,
            "enabled": true
        }
    ]
}
```

I can't think of any way this could break postgres or non-FRDR repositories, so my testing has been limited to sqlite and FRDR.